### PR TITLE
Drop appstream-compose command

### DIFF
--- a/org.kicad.KiCad.Library.Templates.yml
+++ b/org.kicad.KiCad.Library.Templates.yml
@@ -17,8 +17,6 @@ modules:
       # Copy `kicad.kicad_pro` template file from main source tree
       - install -m644 --target-directory=${FLATPAK_DEST}/template kicad/resources/project_template/kicad.kicad_pro
       - install -Dm644 --target-directory=${FLATPAK_DEST}/share/metainfo org.kicad.KiCad.Library.Templates.metainfo.xml
-      - appstream-compose --basename=org.kicad.KiCad.Library.Templates --prefix=${FLATPAK_DEST}
-        --origin=flatpak org.kicad.KiCad.Library.Templates
     sources:
       - type: git
         url: https://gitlab.com/kicad/libraries/kicad-templates.git


### PR DESCRIPTION
This is done in preparation for FDO SDK 24.08, which will not provide this command anymore. Also according to official docs:

> Flatpak-builder (>= 1.3.4), can compose metadata for extensions
> automatically and it is no longer required to manually compose them
> through commands in the manifest.

(https://docs.flatpak.org/en/latest/extension.html#extension-manifest)